### PR TITLE
feat: Implement user profile view and update feature

### DIFF
--- a/src/main/java/com/ieum/user/controller/UserController.java
+++ b/src/main/java/com/ieum/user/controller/UserController.java
@@ -2,19 +2,21 @@ package com.ieum.user.controller;
 
 import com.ieum.common.dto.ApiResponse;
 import com.ieum.common.dto.ErrorResponse;
+import com.ieum.user.dto.CustomUserDetails;
+import com.ieum.user.dto.request.ProfileUpdateRequest;
 import com.ieum.user.dto.request.SignUpRequest;
+import com.ieum.user.dto.response.ProfileResponse;
 import com.ieum.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
@@ -34,6 +36,36 @@ public class UserController {
     @PostMapping("/sign-up")
     public ApiResponse<Void> signUp(@Valid @RequestBody SignUpRequest request) {
         userService.signUp(request);
+        return ApiResponse.success(null);
+    }
+    // 1. 내 정보 조회 API 추가
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 프로필 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 조회 성공", content = @Content(schema = @Schema(implementation = ProfileResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth") // 이 API는 인증이 필요함을 Swagger에 명시
+    @GetMapping("/me")
+    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        ProfileResponse profile = userService.getUserProfile(userId);
+        return ApiResponse.success(profile);
+    }
+
+    // 2. 내 정보 수정 API 추가
+    @Operation(summary = "내 정보 수정", description = "현재 로그인된 사용자의 프로필 정보(이름, 자기소개)를 수정합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth") // 이 API는 인증이 필요함을 Swagger에 명시
+    @PatchMapping("/me")
+    public ApiResponse<Void> updateMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ProfileUpdateRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+        userService.updateUserProfile(userId, request);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/ieum/user/domain/User.java
+++ b/src/main/java/com/ieum/user/domain/User.java
@@ -29,11 +29,26 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String studentId;
 
+    @Column(length = 100)
+    private String introduction;
+
+
     @Builder
-    public User(String email, String password, String name, String studentId) {
+    public User(String email, String password, String name, String studentId, String introduction) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.studentId = studentId;
+        this.introduction = introduction;
+    }
+
+    /**
+     * 사용자의 이름과 자기소개를 수정합니다.
+     * @param name 새로운 이름
+     * @param introduction 새로운 자기소개
+     */
+    public void updateProfile(String name, String introduction) {
+        this.name = name;
+        this.introduction = introduction;
     }
 }

--- a/src/main/java/com/ieum/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/ieum/user/dto/CustomUserDetails.java
@@ -15,6 +15,16 @@ public class CustomUserDetails implements UserDetails {
     private final User user;
 
     /**
+     * [추가 제안]
+     * User 엔티티의 ID(PK)를 반환하는 메서드.
+     * 컨트롤러에서 @AuthenticationPrincipal을 통해 주입받은 UserDetails 객체로부터
+     * 손쉽게 사용자의 ID를 얻기 위해 사용됩니다.
+     */
+    public Long getUserId() {
+        return this.user.getId();
+    }
+
+    /**
      * 사용자의 권한 목록을 반환합니다.
      * 현재는 모든 사용자에게 'ROLE_USER' 권한을 부여합니다.
      */

--- a/src/main/java/com/ieum/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/ieum/user/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.ieum.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "내 프로필 정보 수정 요청 DTO")
+public class ProfileUpdateRequest {
+
+    @Schema(description = "새로운 사용자 이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "새로운 자기소개", example = "hello world!")
+    private String introduction;
+}

--- a/src/main/java/com/ieum/user/dto/response/ProfileResponse.java
+++ b/src/main/java/com/ieum/user/dto/response/ProfileResponse.java
@@ -1,0 +1,48 @@
+package com.ieum.user.dto.response;
+
+import com.ieum.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "내 프로필 정보 응답 DTO")
+public class ProfileResponse {
+
+    @Schema(description = "사용자 이메일", example = "ieum@example.com")
+    private String email;
+
+    @Schema(description = "사용자 이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "사용자 학번", example = "202500000")
+    private String studentId;
+
+    @Schema(description = "자기소개", example = "hello world!")
+    private String introduction;
+
+    @Builder
+    private ProfileResponse(String email, String name, String studentId, String introduction) {
+        this.email = email;
+        this.name = name;
+        this.studentId = studentId;
+        this.introduction = introduction;
+    }
+
+    /**
+     * User 엔티티를 ProfileResponse DTO로 변환하는 정적 팩토리 메서드
+     * @param user User 엔티티 객체
+     * @return 변환된 ProfileResponse DTO
+     */
+    public static ProfileResponse from(User user) {
+        return ProfileResponse.builder()
+                .email(user.getEmail())
+                .name(user.getName())
+                .studentId(user.getStudentId())
+                .introduction(user.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/com/ieum/user/service/UserService.java
+++ b/src/main/java/com/ieum/user/service/UserService.java
@@ -3,7 +3,9 @@ package com.ieum.user.service;
 import com.ieum.common.exception.BusinessException;
 import com.ieum.common.exception.ErrorCode;
 import com.ieum.user.domain.User;
+import com.ieum.user.dto.request.ProfileUpdateRequest;
 import com.ieum.user.dto.request.SignUpRequest;
+import com.ieum.user.dto.response.ProfileResponse;
 import com.ieum.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,17 +25,30 @@ public class UserService {
 
         // 중복 email 검증
         if (userRepository.existsByEmail(request.getEmail())) {
-            // 수정된 ErrorCode를 사용합니다.
             throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
         }
 
         // 중복 학번 검증
         if (userRepository.existsByStudentId(request.getStudentId())) {
-            // 수정된 ErrorCode를 사용합니다.
             throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
         }
 
         User user = request.toEntity(passwordEncoder);
         userRepository.save(user);
+    }
+
+    public ProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return ProfileResponse.from(user);
+    }
+
+    @Transactional
+    public void updateUserProfile(Long userId, ProfileUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateProfile(request.getName(), request.getIntroduction());
     }
 }


### PR DESCRIPTION
## Description

로그인한 사용자가 자신의 프로필 정보(이름, 자기소개)를 조회하고 수정하는 백엔드 기능을 구현했습니다. 이 기능은 기존 JWT 인증 시스템을 기반으로 동작하며, @AuthenticationPrincipal을 통해 현재 사용자를 안전하게 식별합니다.

## Key Changes

-   `ProfileResponse`, `ProfileUpdateRequest` DTO를 추가하여 프로필 조회 및 수정 시 데이터 전송을 담당하도록 했습니다.
-   `User` 엔티티에 `introduction` 필드와 프로필 수정을 위한 `updateProfile()` 비즈니스 메서드를 추가했습니다.
-   `UserService`에 `getUserProfile`, `updateUserProfile` 메서드를 구현하여 실제 비즈니스 로직을 처리했습니다.
-   `UserController`에 `GET /api/v1/users/me` 와 `PATCH /api/v1/users/me` API 엔드포인트를 구현했습니다.
-   `@AuthenticationPrincipal` 어노테이션을 활용하여 컨트롤러 단에서 인증된 사용자 정보를 깔끔하고 안전하게 가져오도록 개선했습니다.
-   Swagger 어노테이션을 통해 새로운 API 명세를 작성하고, JWT 인증이 필요함을 명시했습니다.

## Test

1.  Swagger UI에서 `POST /api/v1/auth/login` API로 로그인하여 `accessToken`을 발급받습니다.
2.  우측 상단 'Authorize' 버튼을 눌러, 발급받은 `accessToken`을 등록하여 인증을 완료합니다.
3.  `GET /api/v1/users/me` API를 실행하여 현재 로그인된 사용자의 정보(초기 introduction 값은 null)가 정상적으로 조회되는지 확인합니다.
4.  `PATCH /api/v1/users/me` API를 실행하여 Request body에 수정할 `name`과 `introduction`을 담아 요청하고, `200 OK` 응답을 받는지 확인합니다.
5.  다시 `GET /api/v1/users/me` API를 실행하여 프로필 정보가 4번에서 보낸 내용으로 잘 수정되었는지 최종 확인합니다.

## Other Matters

-   컨트롤러에서 사용자 ID를 효율적으로 얻기 위해 `CustomUserDetails` 클래스에 `getUserId()` 메서드를 추가했습니다.
-   향후 프로필 사진 등 다른 필드를 추가하여 프로필 기능을 확장할 수 있습니다.