### PR TITLE
feat: Implement front-end for Sign-up and Login

### DIFF
--- a/src/main/java/com/ieum/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ieum/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.ieum.common.exception;
 
+import com.ieum.common.dto.ApiResponse;
 import com.ieum.common.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException; // import 추가
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,28 +14,36 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // Spring Security 인증 예외 처리 (로그인 실패 등)
+    @ExceptionHandler(AuthenticationException.class)
+    protected ResponseEntity<ApiResponse<?>> handleAuthenticationException(AuthenticationException e) {
+        log.error("handleAuthenticationException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.AUTHENTICATION_FAILED);
+        return new ResponseEntity<>(ApiResponse.error(response), HttpStatus.UNAUTHORIZED);
+    }
+
     // DTO Validation 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    protected ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("handleMethodArgumentNotValidException", e);
         final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ApiResponse.error(response), HttpStatus.BAD_REQUEST);
     }
 
     // 우리만의 커스텀 예외 처리
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    protected ResponseEntity<ApiResponse<?>> handleBusinessException(final BusinessException e) {
         log.error("handleBusinessException", e);
         final ErrorCode errorCode = e.getErrorCode();
         final ErrorResponse response = ErrorResponse.of(errorCode);
-        return new ResponseEntity<>(response, errorCode.getStatus());
+        return new ResponseEntity<>(ApiResponse.error(response), errorCode.getStatus());
     }
 
     // 그 외 모든 예외 처리
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    protected ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("handleException", e);
         final ErrorResponse response = ErrorResponse.of(ErrorCode.SERVER_ERROR);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(ApiResponse.error(response), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/ieum/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ieum/user/dto/request/SignUpRequest.java
@@ -26,12 +26,16 @@ public class SignUpRequest {
     @NotBlank(message = "학번은 필수 입력 항목입니다.")
     private String studentId;
 
+    @Size(max = 100, message = "자기소개는 100자 이내로 입력해주세요.")
+    private String introduction;
+
     public User toEntity(PasswordEncoder passwordEncoder) {
         return User.builder()
                 .email(this.email)
                 .password(passwordEncoder.encode(this.password))
                 .name(this.name)
                 .studentId(this.studentId)
+                .introduction(this.introduction)
                 .build();
     }
 }

--- a/src/main/resources/static/auth.js
+++ b/src/main/resources/static/auth.js
@@ -1,12 +1,87 @@
 document.addEventListener('DOMContentLoaded', () => {
 
-    // 로그인 페이지
-    const emailLoginTabBtn = document.getElementById('email-login-tab-btn');
-    const studentIdLoginTabBtn = document.getElementById('student-id-login-tab-btn');
+    // --- 공통 헬퍼 함수 ---
+
+    // 모든 에러 메시지를 지우는 함수
+    const clearErrorMessages = (form) => {
+        form.querySelectorAll('.error-message').forEach(p => p.textContent = '');
+    };
+
+    // 특정 필드에 에러 메시지를 표시하는 함수
+    const displayFieldError = (form, field, message) => {
+        const errorElement = form.querySelector(`[name="${field}"] + .error-message`);
+        if (errorElement) {
+            errorElement.textContent = message;
+        }
+    };
+
+    // API 요청 및 응답 처리를 위한 공통 함수
+    const handleFormSubmit = async (form, endpoint, successCallback) => {
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            clearErrorMessages(form);
+
+            const formData = new FormData(form);
+            const requestBody = Object.fromEntries(formData.entries());
+
+            try {
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody),
+                });
+
+                const responseData = await response.json();
+
+                if (response.ok) {
+                    successCallback(responseData.data);
+                } else {
+                    const errorInfo = responseData.error;
+                    console.error('API Error:', errorInfo); // 디버깅을 위해 에러 정보 전체를 콘솔에 출력
+
+                    // 1. 유효성 검사 에러 처리 (INVALID_INPUT_VALUE)
+                    if (errorInfo && errorInfo.code === 'INVALID_INPUT_VALUE' && errorInfo.errors) {
+                        errorInfo.errors.forEach(err => displayFieldError(form, err.field, err.reason));
+                    }
+                    // 2. 그 외 백엔드에서 정의된 모든 종류의 에러 처리
+                    else if (errorInfo && errorInfo.message) {
+                        alert(errorInfo.message); // ex: "인증에 실패했습니다."
+                    }
+                    // 3. 예상치 못한 형태의 에러일 경우
+                    else {
+                        alert('알 수 없는 오류가 발생했습니다. 개발자 콘솔을 확인해주세요.');
+                    }
+                }
+            } catch (error) {
+                console.error('Fetch error:', error);
+                alert('서버와 통신 중 오류가 발생했습니다.');
+            }
+        });
+    };
+
+
+    // --- 페이지별 기능 초기화 ---
+
+    // 로그인 페이지 기능 초기화
     const emailLoginForm = document.getElementById('email-login-form');
     const studentIdLoginForm = document.getElementById('student-id-login-form');
 
-    if (emailLoginTabBtn && studentIdLoginTabBtn && emailLoginForm && studentIdLoginForm) {
+    if (emailLoginForm && studentIdLoginForm) {
+        // 로그인 성공 시 실행될 콜백 함수
+        const handleLoginSuccess = (data) => {
+            localStorage.setItem('accessToken', data.accessToken);
+            localStorage.setItem('refreshToken', data.refreshToken);
+            alert('로그인 성공!');
+            window.location.href = '/'; // 메인 페이지로 이동 (지금은 없으므로 루트로 설정)
+        };
+
+        // 각 로그인 폼에 공통 핸들러 연결
+        handleFormSubmit(emailLoginForm, '/api/v1/auth/login/email', handleLoginSuccess);
+        handleFormSubmit(studentIdLoginForm, '/api/v1/auth/login/student-id', handleLoginSuccess);
+
+        // 탭 전환 기능
+        const emailLoginTabBtn = document.getElementById('email-login-tab-btn');
+        const studentIdLoginTabBtn = document.getElementById('student-id-login-tab-btn');
         emailLoginTabBtn.addEventListener('click', () => {
             emailLoginForm.style.display = 'flex';
             studentIdLoginForm.style.display = 'none';
@@ -21,56 +96,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // 회원가입 페이지
+    // 회원가입 페이지 기능 초기화
     const signupForm = document.getElementById('signup-form');
-
     if (signupForm) {
-        const clearErrorMessages = () => {
-            document.querySelectorAll('.error-message').forEach(p => p.textContent = '');
-        };
-
-        const displayFieldError = (field, message) => {
-            const errorElement = document.querySelector(`[name="${field}"] + .error-message`);
-            if (errorElement) {
-                errorElement.textContent = message;
-            }
-        };
-
-        signupForm.addEventListener('submit', async (event) => {
-            event.preventDefault();
-            clearErrorMessages();
-
-            const formData = new FormData(signupForm);
-            const requestBody = Object.fromEntries(formData.entries());
-
-            try {
-                const response = await fetch('/api/v1/users/sign-up', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(requestBody),
-                });
-
-                const responseData = await response.json();
-
-                if (response.ok) {
-                    alert('회원가입이 성공적으로 완료되었습니다! 로그인 페이지로 이동합니다.');
-                    window.location.href = 'login.html';
-                } else {
-                    const errorInfo = responseData.error;
-                    if (errorInfo && errorInfo.code === 'INVALID_INPUT_VALUE') {
-                        errorInfo.errors.forEach(err => {
-                            displayFieldError(err.field, err.reason);
-                        });
-                    } else if (errorInfo) {
-                        alert(errorInfo.message || '알 수 없는 오류가 발생했습니다.');
-                    } else {
-                        alert('알 수 없는 오류가 발생했습니다.');
-                    }
-                }
-            } catch (error) {
-                console.error('Sign-up fetch error:', error);
-                alert('서버와 통신 중 오류가 발생했습니다.');
-            }
+        handleFormSubmit(signupForm, '/api/v1/users/sign-up', () => {
+            alert('회원가입이 성공적으로 완료되었습니다! 로그인 페이지로 이동합니다.');
+            window.location.href = 'login.html';
         });
     }
+
 });

--- a/src/main/resources/static/auth.js
+++ b/src/main/resources/static/auth.js
@@ -1,0 +1,31 @@
+    document.addEventListener('DOMContentLoaded', () => {
+
+        const emailLoginTabBtn = document.getElementById('email-login-tab-btn');
+        const studentIdLoginTabBtn = document.getElementById('student-id-login-tab-btn');
+        const emailLoginForm = document.getElementById('email-login-form');
+        const studentIdLoginForm = document.getElementById('student-id-login-form');
+
+        // null 체크
+        if (emailLoginTabBtn && studentIdLoginTabBtn && emailLoginForm && studentIdLoginForm) {
+
+            // 이메일 로그인
+            emailLoginTabBtn.addEventListener('click', () => {
+                emailLoginForm.style.display = 'block';
+                studentIdLoginForm.style.display = 'none';
+
+                // 이메일은 active, 학번은 제거
+                emailLoginTabBtn.classList.add('active');
+                studentIdLoginTabBtn.classList.remove('active');
+            });
+
+            // 학번 로그인
+            studentIdLoginTabBtn.addEventListener('click', () => {
+                emailLoginForm.style.display = 'none';
+                studentIdLoginForm.style.display = 'block';
+
+                // 학번은 active, 이메일은 제거
+                studentIdLoginTabBtn.classList.add('active');
+                emailLoginTabBtn.classList.remove('active');
+            });
+        }
+    });

--- a/src/main/resources/static/auth.js
+++ b/src/main/resources/static/auth.js
@@ -1,31 +1,76 @@
-    document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
 
-        const emailLoginTabBtn = document.getElementById('email-login-tab-btn');
-        const studentIdLoginTabBtn = document.getElementById('student-id-login-tab-btn');
-        const emailLoginForm = document.getElementById('email-login-form');
-        const studentIdLoginForm = document.getElementById('student-id-login-form');
+    // 로그인 페이지
+    const emailLoginTabBtn = document.getElementById('email-login-tab-btn');
+    const studentIdLoginTabBtn = document.getElementById('student-id-login-tab-btn');
+    const emailLoginForm = document.getElementById('email-login-form');
+    const studentIdLoginForm = document.getElementById('student-id-login-form');
 
-        // null 체크
-        if (emailLoginTabBtn && studentIdLoginTabBtn && emailLoginForm && studentIdLoginForm) {
+    if (emailLoginTabBtn && studentIdLoginTabBtn && emailLoginForm && studentIdLoginForm) {
+        emailLoginTabBtn.addEventListener('click', () => {
+            emailLoginForm.style.display = 'flex';
+            studentIdLoginForm.style.display = 'none';
+            emailLoginTabBtn.classList.add('active');
+            studentIdLoginTabBtn.classList.remove('active');
+        });
+        studentIdLoginTabBtn.addEventListener('click', () => {
+            emailLoginForm.style.display = 'none';
+            studentIdLoginForm.style.display = 'flex';
+            studentIdLoginTabBtn.classList.add('active');
+            emailLoginTabBtn.classList.remove('active');
+        });
+    }
 
-            // 이메일 로그인
-            emailLoginTabBtn.addEventListener('click', () => {
-                emailLoginForm.style.display = 'block';
-                studentIdLoginForm.style.display = 'none';
+    // 회원가입 페이지
+    const signupForm = document.getElementById('signup-form');
 
-                // 이메일은 active, 학번은 제거
-                emailLoginTabBtn.classList.add('active');
-                studentIdLoginTabBtn.classList.remove('active');
-            });
+    if (signupForm) {
+        const clearErrorMessages = () => {
+            document.querySelectorAll('.error-message').forEach(p => p.textContent = '');
+        };
 
-            // 학번 로그인
-            studentIdLoginTabBtn.addEventListener('click', () => {
-                emailLoginForm.style.display = 'none';
-                studentIdLoginForm.style.display = 'block';
+        const displayFieldError = (field, message) => {
+            const errorElement = document.querySelector(`[name="${field}"] + .error-message`);
+            if (errorElement) {
+                errorElement.textContent = message;
+            }
+        };
 
-                // 학번은 active, 이메일은 제거
-                studentIdLoginTabBtn.classList.add('active');
-                emailLoginTabBtn.classList.remove('active');
-            });
-        }
-    });
+        signupForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            clearErrorMessages();
+
+            const formData = new FormData(signupForm);
+            const requestBody = Object.fromEntries(formData.entries());
+
+            try {
+                const response = await fetch('/api/v1/users/sign-up', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody),
+                });
+
+                const responseData = await response.json();
+
+                if (response.ok) {
+                    alert('회원가입이 성공적으로 완료되었습니다! 로그인 페이지로 이동합니다.');
+                    window.location.href = 'login.html';
+                } else {
+                    const errorInfo = responseData.error;
+                    if (errorInfo && errorInfo.code === 'INVALID_INPUT_VALUE') {
+                        errorInfo.errors.forEach(err => {
+                            displayFieldError(err.field, err.reason);
+                        });
+                    } else if (errorInfo) {
+                        alert(errorInfo.message || '알 수 없는 오류가 발생했습니다.');
+                    } else {
+                        alert('알 수 없는 오류가 발생했습니다.');
+                    }
+                }
+            } catch (error) {
+                console.error('Sign-up fetch error:', error);
+                alert('서버와 통신 중 오류가 발생했습니다.');
+            }
+        });
+    }
+});

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
     <title>이음 - 로그인</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div class="container">
@@ -14,15 +14,27 @@
         <button id="student-id-login-tab-btn">학번으로 로그인</button>
     </div>
 
-    <form id="email-login-form">
-        <input type="email" id="email-login" name="email" placeholder="이메일" required>
-        <input type="password" id="password-login" name="password" placeholder="비밀번호" required>
+    <form id="email-login-form" novalidate>
+        <div>
+            <input type="email" id="email-login" name="email" placeholder="이메일" required>
+            <p class="error-message"></p>
+        </div>
+        <div>
+            <input type="password" id="password-login" name="password" placeholder="비밀번호" required>
+            <p class="error-message"></p>
+        </div>
         <button type="submit">로그인</button>
     </form>
 
-    <form id="student-id-login-form" style="display:none;">
-        <input type="text" id="studentId-login" name="studentId" placeholder="학번" required>
-        <input type="password" id="password-student" name="password" placeholder="비밀번호" required>
+    <form id="student-id-login-form" style="display:none;" novalidate>
+        <div>
+            <input type="text" id="studentId-login" name="studentId" placeholder="학번" required>
+            <p class="error-message"></p>
+        </div>
+        <div>
+            <input type="password" id="password-student" name="password" placeholder="비밀번호" required>
+            <p class="error-message"></p>
+        </div>
         <button type="submit">로그인</button>
     </form>
 

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이음 - 로그인</title>
+</head>
+<body>
+<div class="container">
+    <h1>로그인</h1>
+    <div class="tab-buttons">
+        <button id="email-login-tab-btn" class="active">이메일로 로그인</button>
+        <button id="student-id-login-tab-btn">학번으로 로그인</button>
+    </div>
+
+    <form id="email-login-form">
+        <input type="email" id="email-login" name="email" placeholder="이메일" required>
+        <input type="password" id="password-login" name="password" placeholder="비밀번호" required>
+        <button type="submit">로그인</button>
+    </form>
+
+    <form id="student-id-login-form" style="display:none;">
+        <input type="text" id="studentId-login" name="studentId" placeholder="학번" required>
+        <input type="password" id="password-student" name="password" placeholder="비밀번호" required>
+        <button type="submit">로그인</button>
+    </form>
+
+    <p>계정이 없으신가요? <a href="signup.html">회원가입</a></p>
+</div>
+
+<script src="auth.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
     <title>이음 - 로그인</title>
 </head>
 <body>

--- a/src/main/resources/static/signup.html
+++ b/src/main/resources/static/signup.html
@@ -3,18 +3,33 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
     <title>이음 - 회원가입</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div class="container">
     <h1>회원가입</h1>
-    <form id="signup-form">
-        <input type="email" id="email" name="email" placeholder="이메일" required>
-        <input type="password" id="password" name="password" placeholder="비밀번호" required>
-        <input type="text" id="name" name="name" placeholder="이름" required>
-        <input type="text" id="studentId" name="studentId" placeholder="학번" required>
-        <textarea id="introduction" name="introduction" placeholder="자기소개 (최대 100자)"></textarea>
+    <form id="signup-form" novalidate>
+        <div>
+            <input type="email" id="email" name="email" placeholder="이메일" required>
+            <p class="error-message"></p>
+        </div>
+        <div>
+            <input type="password" id="password" name="password" placeholder="비밀번호" required>
+            <p class="error-message"></p>
+        </div>
+        <div>
+            <input type="text" id="name" name="name" placeholder="이름" required>
+            <p class="error-message"></p>
+        </div>
+        <div>
+            <input type="text" id="studentId" name="studentId" placeholder="학번" required>
+            <p class="error-message"></p>
+        </div>
+        <div>
+            <textarea id="introduction" name="introduction" placeholder="자기소개 (최대 100자)"></textarea>
+            <p class="error-message"></p>
+        </div>
         <button type="submit">가입하기</button>
     </form>
     <p>이미 계정이 있으신가요? <a href="login.html">로그인</a></p>

--- a/src/main/resources/static/signup.html
+++ b/src/main/resources/static/signup.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
     <title>이음 - 회원가입</title>
 </head>
 <body>
@@ -13,7 +14,7 @@
         <input type="password" id="password" name="password" placeholder="비밀번호" required>
         <input type="text" id="name" name="name" placeholder="이름" required>
         <input type="text" id="studentId" name="studentId" placeholder="학번" required>
-        <textarea id="introduction" name="introduction" placeholder="자기소개를 입력하세요"></textarea>
+        <textarea id="introduction" name="introduction" placeholder="자기소개 (최대 100자)"></textarea>
         <button type="submit">가입하기</button>
     </form>
     <p>이미 계정이 있으신가요? <a href="login.html">로그인</a></p>

--- a/src/main/resources/static/signup.html
+++ b/src/main/resources/static/signup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이음 - 회원가입</title>
+</head>
+<body>
+<div class="container">
+    <h1>회원가입</h1>
+    <form id="signup-form">
+        <input type="email" id="email" name="email" placeholder="이메일" required>
+        <input type="password" id="password" name="password" placeholder="비밀번호" required>
+        <input type="text" id="name" name="name" placeholder="이름" required>
+        <input type="text" id="studentId" name="studentId" placeholder="학번" required>
+        <textarea id="introduction" name="introduction" placeholder="자기소개를 입력하세요"></textarea>
+        <button type="submit">가입하기</button>
+    </form>
+    <p>이미 계정이 있으신가요? <a href="login.html">로그인</a></p>
+</div>
+<script src="auth.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -28,10 +28,7 @@ h1 {
 form {
     display: flex;
     flex-direction: column;
-}
-
-form > *:not(:last-child) {
-    margin-bottom: 1rem;
+    gap: 0.5rem;
 }
 
 input, textarea, button {
@@ -58,33 +55,37 @@ button[type="submit"] {
     transition: background-color 0.2s;
 }
 
-button[type="submit"]:hover {
-    background-color: #0056b3;
+.error-message {
+    color: #dc3545;
+    font-size: 0.8rem;
+    text-align: left;
+    margin-top: 0.2rem;
 }
 
 /* Tab Buttons on Login Page */
 .tab-buttons {
     display: flex;
     margin-bottom: 1.5rem;
+    border-bottom: 1px solid #ddd; /* 컨테이너 전체에 밑줄을 추가합니다. */
 }
 
 #email-login-tab-btn, #student-id-login-tab-btn {
     flex: 1;
     padding: 0.8rem;
     border: 1px solid #ddd;
-    border-bottom: none;
+    border-bottom: none; /* 각 버튼의 밑줄은 없습니다. */
     background-color: #f8f9fa;
     cursor: pointer;
     border-radius: 0;
 }
 
 #email-login-tab-btn.active, #student-id-login-tab-btn.active {
-    background-color: white;
-    border-bottom: 1px solid white;
+    background-color: white; /* 활성화된 탭은 배경을 흰색으로 */
     position: relative;
-    top: 1px;
+    top: 1px; /* 아래 컨테이너의 밑줄을 덮도록 1px 아래로 이동 */
 }
 
+/* 탭의 좌우 모서리 둥글게 처리 */
 #email-login-tab-btn {
     border-top-left-radius: 4px;
 }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -28,7 +28,10 @@ h1 {
 form {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+}
+
+form > *:not(:last-child) {
+    margin-bottom: 1rem;
 }
 
 input, textarea, button {
@@ -38,6 +41,7 @@ input, textarea, button {
     border: 1px solid #ddd;
     box-sizing: border-box;
     font-size: 1rem;
+    font-family: inherit;
 }
 
 textarea {

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,105 @@
+/* General Layout */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background-color: #f4f4f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    background: white;
+    padding: 2rem 2.5rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    width: 100%;
+    max-width: 400px;
+    text-align: center;
+}
+
+h1 {
+    margin-bottom: 1.5rem;
+    color: #333;
+}
+
+/* Form Elements */
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+input, textarea, button {
+    width: 100%;
+    padding: 0.8rem;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    box-sizing: border-box;
+    font-size: 1rem;
+}
+
+textarea {
+    resize: vertical;
+    min-height: 80px;
+}
+
+button[type="submit"] {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.2s;
+}
+
+button[type="submit"]:hover {
+    background-color: #0056b3;
+}
+
+/* Tab Buttons on Login Page */
+.tab-buttons {
+    display: flex;
+    margin-bottom: 1.5rem;
+}
+
+#email-login-tab-btn, #student-id-login-tab-btn {
+    flex: 1;
+    padding: 0.8rem;
+    border: 1px solid #ddd;
+    border-bottom: none;
+    background-color: #f8f9fa;
+    cursor: pointer;
+    border-radius: 0;
+}
+
+#email-login-tab-btn.active, #student-id-login-tab-btn.active {
+    background-color: white;
+    border-bottom: 1px solid white;
+    position: relative;
+    top: 1px;
+}
+
+#email-login-tab-btn {
+    border-top-left-radius: 4px;
+}
+
+#student-id-login-tab-btn {
+    border-top-right-radius: 4px;
+}
+
+/* Links */
+p {
+    margin-top: 1.5rem;
+    font-size: 0.9rem;
+}
+
+a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Description

'이음' 서비스의 사용자 인증을 위한 회원가입 및 로그인 페이지의 UI를 구현하고, 백엔드 API와 연동합니다. 이메일 또는 학번으로 로그인할 수 있는 탭 UI를 제공하며, 서버와 연동된 상세한 클라이언트 측 에러 처리를 포함합니다.

<br>

## Key Changes

- **Backend**
    - `build.gradle`에 `spring-boot-starter-validation` 의존성을 추가하여 서버 측 유효성 검사가 동작하도록 수정했습니다.
    - `GlobalExceptionHandler`를 수정하여 `AuthenticationException`을 처리하고, 모든 예외 응답 형식을 `ApiResponse`로 통일하여 일관성을 확보했습니다.
- **Frontend**
    - `signup.html`, `login.html`: 회원가입과 로그인을 위한 기본 마크업 및 에러 메시지를 표시할 영역을 생성했습니다.
    - `style.css`: 사용자 경험을 고려한 UI 스타일을 적용했습니다.
    - `auth.js`: 모든 클라이언트 사이드 로직을 구현했습니다.
        - 로그인 페이지의 탭 전환 기능
        - 회원가입 API 연동 및 필드별 유효성 검사 에러를 입력창 하단에 표시하는 기능
        - 이메일/학번 로그인 API 연동, 로그인 성공 시 `localStorage`에 토큰 저장, 실패 시 구체적인 에러 메시지 팝업 기능
        - 폼 제출 및 API 연동 로직을 `handleFormSubmit` 공통 함수로 리팩토링하여 코드 중복을 최소화했습니다.

<br>

## Test

1.  백엔드 서버를 실행합니다.
2.  브라우저에서 `http://localhost:8080/signup.html`로 접속합니다.
3.  **유효성 검사 테스트**: 비밀번호를 8자 미만으로 입력하고 '가입하기'를 클릭했을 때, `alert` 창이 아닌 비밀번호 입력칸 바로 아래에 에러 메시지가 표시되는지 확인합니다.
4.  **중복 가입 테스트**: 이미 가입된 이메일로 가입을 시도하고, '이미 존재하는 리소스입니다.' `alert` 창이 뜨는지 확인합니다.
5.  **회원가입 성공 테스트**: 새로운 정보로 회원가입을 완료하고, `login.html`로 자동 이동되는지 확인합니다.
6.  **로그인 실패 테스트**: 방금 가입한 정보와 다른 비밀번호로 로그인을 시도하고, '인증에 실패했습니다.' `alert` 창이 뜨는지 확인합니다.
7.  **로그인 성공 테스트**: 올바른 정보로 로그인에 성공하고, 성공 `alert`을 확인합니다.
8.  **토큰 저장 확인**: 로그인 성공 후, 개발자 도구(F12)의 'Application' 탭 -> 'Local Storage'에 `accessToken`과 `refreshToken`이 정상적으로 저장되는지 확인합니다.

<br>

## Other Matters

- 프론트엔드 구현 과정에서 발견된 백엔드 예외 처리의 비일관성 문제를 해결하여, 향후 기능 개발 시에도 안정적인 에러 처리가 가능하도록 백엔드 코드를 개선했습니다.