### PR TITLE
docs: Complete API documentation for auth and user features

### DIFF
--- a/src/main/java/com/ieum/auth/controller/AuthController.java
+++ b/src/main/java/com/ieum/auth/controller/AuthController.java
@@ -6,7 +6,11 @@ import com.ieum.auth.dto.request.StudentIdLoginRequest;
 import com.ieum.auth.dto.response.TokenResponse;
 import com.ieum.auth.service.AuthService;
 import com.ieum.common.dto.ApiResponse;
+import com.ieum.common.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "인증", description = "사용자 인증 관련 API")
+@Tag(name = "인증", description = "사용자 인증 및 토큰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -23,21 +27,43 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "이메일 로그인")
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인하고, 인증 토큰을 발급받습니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (비밀번호 불일치 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/login/email")
     public ResponseEntity<ApiResponse<TokenResponse>> loginByEmail(@RequestBody EmailLoginRequest request) {
         TokenResponse tokenResponse = authService.loginByEmail(request);
         return ResponseEntity.ok(ApiResponse.success(tokenResponse));
     }
 
-    @Operation(summary = "학번 로그인")
+    @Operation(summary = "학번 로그인", description = "학번과 비밀번호로 로그인하고, 인증 토큰을 발급받습니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (비밀번호 불일치 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/login/student-id")
     public ResponseEntity<ApiResponse<TokenResponse>> loginByStudentId(@RequestBody StudentIdLoginRequest request) {
         TokenResponse tokenResponse = authService.loginByStudentId(request);
         return ResponseEntity.ok(ApiResponse.success(tokenResponse));
     }
 
-    @Operation(summary = "토큰 재발급")
+    @Operation(summary = "토큰 재발급", description = "만료된 Access Token을 Refresh Token을 사용하여 재발급받습니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<TokenResponse>> reissue(@RequestBody ReissueRequest request) {
         TokenResponse tokenResponse = authService.reissue(request);

--- a/src/main/java/com/ieum/auth/dto/request/EmailLoginRequest.java
+++ b/src/main/java/com/ieum/auth/dto/request/EmailLoginRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class EmailLoginRequest {
 
-    @Schema(description = "사용자 이메일", example = "test@university.ac.kr")
+    @Schema(description = "사용자 이메일", example = "member@ieum.com")
     private String email;
 
     @Schema(description = "비밀번호", example = "password123!")

--- a/src/main/java/com/ieum/auth/dto/request/ReissueRequest.java
+++ b/src/main/java/com/ieum/auth/dto/request/ReissueRequest.java
@@ -9,9 +9,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReissueRequest {
 
-    @Schema(description = "기존 Access Token")
+    @Schema(description = "기존 Access Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtZW1iZXJAaWV1bS5jb20iLCJpYXQiOjE3MjU4NDU5MDIsImV4cCI6MTcyNTg0OTUwMn0.abcdefg123456")
     private String accessToken;
 
-    @Schema(description = "기존 Refresh Token")
+    @Schema(description = "기존 Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtZW1iZXJAaWV1bS5jb20iLCJpYXQiOjE3MjU4NDU5MDIsImV4cCI6MTcyNTg0OTUwMn0.abcdefg123456")
     private String refreshToken;
 }

--- a/src/main/java/com/ieum/auth/dto/request/StudentIdLoginRequest.java
+++ b/src/main/java/com/ieum/auth/dto/request/StudentIdLoginRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StudentIdLoginRequest {
 
-    @Schema(description = "학번", example = "202012345")
+    @Schema(description = "학번", example = "202512345")
     private String studentId;
 
     @Schema(description = "비밀번호", example = "password123!")

--- a/src/main/java/com/ieum/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/ieum/auth/dto/response/TokenResponse.java
@@ -16,9 +16,9 @@ public class TokenResponse {
     @Schema(description = "인증 타입", example = "Bearer")
     private String grantType;
 
-    @Schema(description = "액세스 토큰 (실제 인증 토큰)")
+    @Schema(description = "액세스 토큰 (실제 인증 토큰)", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtZW1iZXJAaWV1bS5jb20iLCJpYXQiOjE3MjU4NDU5MDIsImV4cCI6MTcyNTg0OTUwMn0.abcdefg123456")
     private String accessToken;
 
-    @Schema(description = "리프레시 토큰 (액세스 토큰 재발급용)")
+    @Schema(description = "리프레시 토큰 (액세스 토큰 재발급용)", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJtZW1iZXJAaWV1bS5jb20iLCJpYXQiOjE3MjU4NDU5MDIsImV4cCI6MTcyNTg0OTUwMn0.abcdefg123456")
     private String refreshToken;
 }

--- a/src/main/java/com/ieum/config/SwaggerConfig.java
+++ b/src/main/java/com/ieum/config/SwaggerConfig.java
@@ -1,7 +1,9 @@
 package com.ieum.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -9,37 +11,48 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-// 1. @OpenAPIDefinition 어노테이션 추가
 @OpenAPIDefinition(
         info = @Info(
-                title = "'이음' API 명세서",
-                description = "프로젝트 '이음'의 API 기능들을 설명하는 문서입니다.",
-                version = "v1.0.0"
+                title = "스터디 매칭 플랫폼 '이음' API",
+                description = """
+                        ## 스터디 매칭 플랫폼 '이음' API 명세서
+                        
+                        '이음' 프로젝트의 공식 API 문서입니다.
+                        
+                        - **주요 기능:** 사용자 인증, 프로필 관리, 스터디 그룹 관리 등
+                        - **문의:** 아래 연락처로 문의 바랍니다.
+                        """,
+                version = "1.0.0",
+                contact = @Contact(
+                        name = "박현민",
+                        email = "hungrygamja0106@gmail.com",
+                        url = "https://github.com/rkawkzpark/ieum"
+                ),
+                license = @License(
+                        name = "Apache 2.0",
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.html"
+                )
         )
 )
-
 @Configuration
 public class SwaggerConfig {
 
-        // 2. OpenAPI Bean 설정 변경
         @Bean
         public OpenAPI openAPI() {
-                // Security Scheme 이름
-                String jwtSchemeName = "bearerAuth";
+                // 1. SecurityScheme 설정
+                SecurityScheme securityScheme = new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .in(SecurityScheme.In.HEADER)
+                        .name("Authorization");
 
-                // API 요청 헤더에 인증 정보 포함
-                SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+                // 2. SecurityRequirement 설정
+                SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
-                // Security Schemes 설정
-                Components components = new Components()
-                        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-                                .name(jwtSchemeName)
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT"));
-
+                // 3. OpenAPI 객체에 반영
                 return new OpenAPI()
-                        .components(components)
-                        .addSecurityItem(securityRequirement);
+                        .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                        .security(java.util.Collections.singletonList(securityRequirement));
         }
 }

--- a/src/main/java/com/ieum/user/controller/UserController.java
+++ b/src/main/java/com/ieum/user/controller/UserController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "User", description = "사용자 관련 API")
+@Tag(name = "사용자", description = "사용자 정보 관리 및 회원가입 API")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -29,22 +29,25 @@ public class UserController {
     @Operation(summary = "회원가입", description = "사용자가 이메일, 비밀번호, 이름, 학번을 입력하여 회원가입을 요청합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 입력 값", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 존재하는 리소스 (이메일 또는 학번 중복)", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 입력 값",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 존재하는 리소스 (이메일 또는 학번 중복)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-
     @PostMapping("/sign-up")
     public ApiResponse<Void> signUp(@Valid @RequestBody SignUpRequest request) {
         userService.signUp(request);
         return ApiResponse.success(null);
     }
-    // 1. 내 정보 조회 API 추가
+
     @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 프로필 정보를 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 조회 성공", content = @Content(schema = @Schema(implementation = ProfileResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ProfileResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @SecurityRequirement(name = "bearerAuth") // 이 API는 인증이 필요함을 Swagger에 명시
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/me")
     public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
@@ -52,13 +55,13 @@ public class UserController {
         return ApiResponse.success(profile);
     }
 
-    // 2. 내 정보 수정 API 추가
     @Operation(summary = "내 정보 수정", description = "현재 로그인된 사용자의 프로필 정보(이름, 자기소개)를 수정합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 수정 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @SecurityRequirement(name = "bearerAuth") // 이 API는 인증이 필요함을 Swagger에 명시
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/me")
     public ApiResponse<Void> updateMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/ieum/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/ieum/user/dto/request/ProfileUpdateRequest.java
@@ -9,9 +9,9 @@ import lombok.NoArgsConstructor;
 @Schema(description = "내 프로필 정보 수정 요청 DTO")
 public class ProfileUpdateRequest {
 
-    @Schema(description = "새로운 사용자 이름", example = "홍길동")
+    @Schema(description = "수정할 이름", example = "김이음")
     private String name;
 
-    @Schema(description = "새로운 자기소개", example = "hello world!")
+    @Schema(description = "수정할 자기소개", example = "안녕하세요. '이음'입니다.")
     private String introduction;
 }

--- a/src/main/java/com/ieum/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ieum/user/dto/request/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.ieum.user.dto.request;
 
 import com.ieum.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -10,23 +11,29 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "회원가입 요청 DTO")
 public class SignUpRequest {
 
     @NotBlank(message = "이메일은 필수 입력 항목입니다.")
     @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @Schema(description = "사용자 이메일", example = "member@ieum.com")
     private String email;
 
     @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Schema(description = "비밀번호 (8자 이상)", example = "password123!")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 항목입니다.")
+    @Schema(description = "사용자 이름", example = "김이음")
     private String name;
 
     @NotBlank(message = "학번은 필수 입력 항목입니다.")
+    @Schema(description = "사용자 학번", example = "202512345")
     private String studentId;
 
     @Size(max = 100, message = "자기소개는 100자 이내로 입력해주세요.")
+    @Schema(description = "자기소개 (100자 이내)", example = "안녕하세요. '이음'입니다.")
     private String introduction;
 
     public User toEntity(PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/ieum/user/dto/response/ProfileResponse.java
+++ b/src/main/java/com/ieum/user/dto/response/ProfileResponse.java
@@ -12,16 +12,16 @@ import lombok.NoArgsConstructor;
 @Schema(description = "내 프로필 정보 응답 DTO")
 public class ProfileResponse {
 
-    @Schema(description = "사용자 이메일", example = "ieum@example.com")
+    @Schema(description = "사용자 이메일", example = "member@ieum.com")
     private String email;
 
-    @Schema(description = "사용자 이름", example = "홍길동")
+    @Schema(description = "사용자 이름", example = "김이음")
     private String name;
 
-    @Schema(description = "사용자 학번", example = "202500000")
+    @Schema(description = "사용자 학번", example = "202512345")
     private String studentId;
 
-    @Schema(description = "자기소개", example = "hello world!")
+    @Schema(description = "자기소개", example = "안녕하세요. '이음'입니다.")
     private String introduction;
 
     @Builder
@@ -32,11 +32,6 @@ public class ProfileResponse {
         this.introduction = introduction;
     }
 
-    /**
-     * User 엔티티를 ProfileResponse DTO로 변환하는 정적 팩토리 메서드
-     * @param user User 엔티티 객체
-     * @return 변환된 ProfileResponse DTO
-     */
     public static ProfileResponse from(User user) {
         return ProfileResponse.builder()
                 .email(user.getEmail())


### PR DESCRIPTION
### Description

개발자 경험(DX) 향상을 위해 사용자 인증(`auth`) 및 프로필(`user`) 관련 API 문서를 전반적으로 개선하고 표준화했습니다.

Swagger UI 명세서만으로 API의 모든 기능, 요청/응답 형식, 예외 처리 상황을 명확하게 파악하고 테스트할 수 있도록 하여 협업 효율성을 높이는 것을 목표로 합니다.

### Key Changes

#### **1. DTO Schema**
* `auth`, `user` 패키지 내 모든 Request/Response DTO에 `@Schema` 어노테이션을 적용했습니다.
* 모든 필드에 **`description` (설명)**과 일관된 스타일의 **`example` (예시 값)**을 추가하여 데이터 명세의 가독성을 확보했습니다.

#### **2. API Controllers**
* **AuthController**: 로그인, 토큰 재발급 API에 상세한 `description`과 `ApiResponses` (200, 401, 404 등)를 추가하여 응답 케이스를 명세화했습니다.
* **UserController**: 기존 문서를 기반으로 `@Tag` 이름을 통일하여 전체 문서의 일관성을 높였습니다.

#### **3. Swagger Configuration**
* `SwaggerConfig`를 개선하여 API 문서의 제목, 설명, 개발자 연락처, 라이선스 등 **전역 메타데이터**를 보강했습니다.
* Markdown을 활용해 설명(description)의 가독성을 높였습니다.

### Other Matters

* 이번 PR은 API의 실제 로직 변경 없이 **문서 정보 보강**에만 초점을 맞춘 작업입니다.
* 프론트엔드 코드에 영향을 주지 않습니다.