### PR TITLE
feat(study): Add study creation API

### DIFF
--- a/src/main/java/com/ieum/common/controller/RootController.java
+++ b/src/main/java/com/ieum/common/controller/RootController.java
@@ -1,0 +1,17 @@
+package com.ieum.common.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Handles server health checks and requests to the root path (/).
+ */
+@RestController
+public class RootController {
+
+    @GetMapping("/")
+    public ResponseEntity<String> root() {
+        return ResponseEntity.ok("Welcome to Ieum API server!");
+    }
+}

--- a/src/main/java/com/ieum/study/controller/StudyController.java
+++ b/src/main/java/com/ieum/study/controller/StudyController.java
@@ -1,0 +1,37 @@
+package com.ieum.study.controller;
+
+import com.ieum.study.dto.response.StudyCreateResponseDto;
+import com.ieum.study.dto.request.StudyCreateRequestDto;
+import com.ieum.study.service.StudyService;
+import com.ieum.user.domain.User;
+import com.ieum.user.dto.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/studies")
+public class StudyController {
+
+    private final StudyService studyService;
+
+    @PostMapping
+    public ResponseEntity<StudyCreateResponseDto> createStudy(
+            @Valid @RequestBody StudyCreateRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        User user = userDetails.getUser();
+
+        Long studyId = studyService.createStudy(requestDto, user);
+        StudyCreateResponseDto response = new StudyCreateResponseDto(studyId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/ieum/study/dto/request/StudyCreateRequestDto.java
+++ b/src/main/java/com/ieum/study/dto/request/StudyCreateRequestDto.java
@@ -1,0 +1,42 @@
+package com.ieum.study.dto.request;
+
+import com.ieum.study.domain.StudyType;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/**
+ * 스터디 생성을 위한 요청 데이터를 담는 DTO
+ */
+@Getter
+public class StudyCreateRequestDto {
+
+    @NotBlank(message = "스터디 제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "스터디 설명은 필수입니다.")
+    private String description;
+
+    @NotBlank(message = "카테고리는 필수입니다.")
+    private String category;
+
+    @NotNull(message = "스터디 진행 방식은 필수입니다.")
+    private StudyType type;
+
+    private String region; // 오프라인 스터디의 경우
+
+    @NotNull(message = "시작일은 필수입니다.")
+    @FutureOrPresent(message = "시작일은 오늘 또는 그 후로 설정 가능합니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "종료일은 필수입니다.")
+    private LocalDate endDate;
+
+    @NotNull(message = "최대 정원은 필수입니다.")
+    @Min(value = 2, message = "최대 정원은 2명 이상이어야 합니다.")
+    private Integer maxMembers;
+}

--- a/src/main/java/com/ieum/study/dto/response/StudyCreateResponseDto.java
+++ b/src/main/java/com/ieum/study/dto/response/StudyCreateResponseDto.java
@@ -1,0 +1,13 @@
+package com.ieum.study.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 스터디 생성 후 생성된 스터디의 ID를 반환하는 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class StudyCreateResponseDto {
+    private Long studyId;
+}

--- a/src/main/java/com/ieum/study/repository/MembershipRepository.java
+++ b/src/main/java/com/ieum/study/repository/MembershipRepository.java
@@ -1,0 +1,7 @@
+package com.ieum.study.repository;
+
+import com.ieum.study.domain.Membership;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MembershipRepository extends JpaRepository<Membership, Long> {
+}

--- a/src/main/java/com/ieum/study/repository/StudyRepository.java
+++ b/src/main/java/com/ieum/study/repository/StudyRepository.java
@@ -1,0 +1,7 @@
+package com.ieum.study.repository;
+
+import com.ieum.study.domain.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRepository extends JpaRepository<Study, Long> {
+}

--- a/src/main/java/com/ieum/study/service/StudyService.java
+++ b/src/main/java/com/ieum/study/service/StudyService.java
@@ -1,0 +1,59 @@
+package com.ieum.study.service;
+
+import com.ieum.study.domain.Membership;
+import com.ieum.study.domain.Study;
+import com.ieum.study.domain.StudyRole;
+import com.ieum.study.domain.StudyStatus;
+import com.ieum.study.dto.request.StudyCreateRequestDto;
+import com.ieum.study.repository.MembershipRepository;
+import com.ieum.study.repository.StudyRepository;
+import com.ieum.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StudyService {
+
+    private final StudyRepository studyRepository;
+    private final MembershipRepository membershipRepository;
+
+    /**
+     * 새로운 스터디를 생성하고, 요청한 사용자를 스터디장으로 지정합니다.
+     * @param requestDto 스터디 생성 요청 데이터
+     * @param user       인증된 사용자 정보 (스터디장이 될 사용자)
+     * @return 생성된 스터디의 ID
+     */
+    @Transactional
+    public Long createStudy(StudyCreateRequestDto requestDto, User user) {
+        // 1. DTO를 Study 엔티티로 변환 (상태는 RECRUITING으로 초기화)
+        Study newStudy = Study.builder()
+                .title(requestDto.getTitle())
+                .description(requestDto.getDescription())
+                .category(requestDto.getCategory())
+                .type(requestDto.getType())
+                .region(requestDto.getRegion())
+                .startDate(requestDto.getStartDate())
+                .endDate(requestDto.getEndDate())
+                .maxMembers(requestDto.getMaxMembers())
+                .status(StudyStatus.RECRUITING)
+                .build();
+
+        // 2. Study 엔티티를 데이터베이스에 저장
+        Study savedStudy = studyRepository.save(newStudy);
+
+        // 3. 요청한 사용자를 LEADER로 하는 Membership 엔티티 생성
+        Membership leaderMembership = Membership.builder()
+                .user(user)
+                .study(savedStudy)
+                .role(StudyRole.LEADER)
+                .build();
+
+        // 4. Membership 엔티티를 데이터베이스에 저장
+        membershipRepository.save(leaderMembership);
+
+        // 5. 생성된 스터디의 ID 반환
+        return savedStudy.getId();
+    }
+}

--- a/src/main/java/com/ieum/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/ieum/user/dto/CustomUserDetails.java
@@ -2,6 +2,7 @@ package com.ieum.user.dto;
 
 import com.ieum.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 @RequiredArgsConstructor
+@Getter
 public class CustomUserDetails implements UserDetails {
 
     private final User user;


### PR DESCRIPTION
### Description

서버 안정성을 강화하고, 프로젝트의 핵심 기능인 '스터디 생성 API'를 구현합니다.

이번 PR을 통해 인증된 사용자는 새로운 스터디 그룹을 생성하고, 생성과 동시에 해당 스터디의 리더(`LEADER`)로 자동 지정됩니다. 또한, Graceful Shutdown 설정 등을 통해 배포 안정성을 향상시킵니다.

### Key Changes

- **서버 안정성 강화**:
    - `application.yml`에 **Graceful Shutdown** 설정을 추가하여 배포 시 안전한 서버 종료를 보장합니다.
    - Render 환경 변수에 **KST 시간대(`Asia/Seoul`)** 설정을 적용하여 시간 기록을 통일합니다.
    - 불필요한 404 에러 로그 방지를 위해 **루트 경로 핸들러(`RootController`)**를 추가했습니다.

- **스터디 생성 API 구현**:
    - 인증된 사용자가 스터디를 생성할 수 있는 `POST /api/v1/studies` 엔드포인트를 구현했습니다.
    - DTO(`StudyCreateRequestDto`, `StudyCreateResponseDto`), Controller, Service, Repository 각 계층의 역할을 분리하여 기능을 설계했습니다.
    - 스터디 생성 시, 요청한 사용자를 `LEADER` 역할로 하는 `Membership` 정보가 함께 생성되도록 비즈니스 로직을 구현했습니다.

### Test

- **Postman을 이용한 통합 테스트 완료**:
    - 유효한 인증 토큰과 요청 데이터를 사용하여 `POST /api/v1/studies` API를 호출했습니다.
    - 서버가 **`201 Created`** 상태 코드와 함께 생성된 **`studyId`**를 정상적으로 반환하는 것을 확인했습니다.
    - Postman의